### PR TITLE
1. ops(infra): ec2 재배포

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -8,11 +8,10 @@ USE_REMOTE_API=true
 # SSL 인증서
 SSL_KEY_PATH=src/config/https/localhost-key.pem
 SSL_CERT_PATH=src/config/https/localhost.pem
-SSL_CA_PATH=src/config/https/ec2-public-ip.crt
 
 # API 서버 URL
-API_URL_PROD=https://ec2-3-36-70-95.ap-northeast-2.compute.amazonaws.com
-WS_URL_PROD=wss://ec2-3-36-70-95.ap-northeast-2.compute.amazonaws.com
+API_URL_PROD=https://ec2-3-39-239-163.ap-northeast-2.compute.amazonaws.com
+WS_URL_PROD=wss://ec2-3-39-239-163.ap-northeast-2.compute.amazonaws.com
 
 
 ### 클라이언트 접근 가능한 환경변수 설정 (NEXT_PUBLIC_)

--- a/.github/workflows/deploy2aws.yml
+++ b/.github/workflows/deploy2aws.yml
@@ -18,6 +18,7 @@ jobs:
           # Github Repository Settings > Security > Secrets and variables > Actions
           # SSH_HOST: HOST IP
           host: ${{ secrets.SSH_HOST }}
+          port: ${{ secrets.SSH_PORT }}  # SSH 포트 지정
           username: ${{ secrets.SSH_USER }}
           # RSA 키페어 중 pem 파일 내용
           key: ${{ secrets.SSH_PRIV_KEY }}

--- a/src/server/httpsServer.js
+++ b/src/server/httpsServer.js
@@ -34,7 +34,6 @@ const handle = app.getRequestHandler();
 const httpsOptions = {
     key: fs.readFileSync(path.resolve(process.env.SSL_KEY_PATH)),       // 개인 키
     cert: fs.readFileSync(path.resolve(process.env.SSL_CERT_PATH)),     // 인증서
-    ca: fs.readFileSync(path.resolve(process.env.SSL_CA_PATH)),         // EC2 인증서 (필요하면 추가)
 };
 
 // Express 서버 생성


### PR DESCRIPTION
- EC2 SSH 접속 포트를 Github 보안 환경변수로 사용하도록 변경
- 불필요한 ec2 ssl 인증서 삭제