### PR TITLE
1. feat: 전체 경기 일정 조회 기능 및 즐겨찾기 스타일 적용

### DIFF
--- a/src/components/CustomEventWrapper.js
+++ b/src/components/CustomEventWrapper.js
@@ -2,7 +2,9 @@ import Popup from 'reactjs-popup';
 import 'reactjs-popup/dist/index.css';
 import { format } from 'date-fns';
 
-
+/**
+ * 일정 클릭 팝업 이벤트
+ */
 const CustomEventWrapper = ({ event, children }) => {
     return (
         <Popup

--- a/src/components/MyCalendar.js
+++ b/src/components/MyCalendar.js
@@ -7,9 +7,10 @@ import '@/styles/tailwind/lol/calendar.css';
 import '@/styles/css/lol-calendar.css';
 import { format, parse, startOfWeek, getDay } from 'date-fns';
 import ko from 'date-fns/locale/ko';
-import { getFavoritTeamSchedule } from '@utils/api-lol.js';
+import {fetchFavoriteTeam, getAllSchedules} from '@utils/api-lol.js';
 import CustomToolbar from '@components/CustomToolbar.js';
 import CustomEventWrapper from "@components/CustomEventWrapper.js";
+import { useAuth } from "@/context/AuthContext.js";
 
 const locales = { ko };
 
@@ -31,10 +32,26 @@ const formats = {
     dayHeaderFormat: 'yyyy-MM-d',
 };
 
+// 로그인 했으면 즐겨찾는 팀 일정 조회 / 즐찾 팀 일정 색상 다르게만?
+// 로그인 안했으면 전체 일정 조회
 const MyCalendar = ({ events }) => {
+    const { userId } = useAuth();
     const [currentView, setCurrentView] = useState('month');
+    const [favoriteTeamCodes, setFavoriteTeamCodes] = useState([]);
     const [rawSchedules, setRawSchedules] = useState([]);
     const [refinedSchedules, setRefinedSchedules] = useState([]);
+
+    useEffect(() => {
+        const fetchSchedule = async () => {
+            if (userId) {
+                const data = await fetchFavoriteTeam(); // displayOrder, teamCode, teamName
+                setFavoriteTeamCodes(data.map(team => team.teamCode));
+            }
+            setRawSchedules(await getAllSchedules()); // 로그인 여부와 상관없이 전체 일정 조회
+        };
+
+        fetchSchedule();
+    }, [userId]);
 
     // 🔄 스케줄 포맷팅 함수 (view에 따라 변형)
     const refineTeamSchedule = useCallback((schedules, view) => {
@@ -69,66 +86,65 @@ const MyCalendar = ({ events }) => {
             });
     }, []);
 
-    // ✅ 최초 1번만 API 호출
-    useEffect(() => {
-        const fetchSchedule = async () => {
-            const schedules = await getFavoritTeamSchedule();
-            setRawSchedules(schedules);
-        };
-
-        fetchSchedule();
-    }, []);
-
     // ✅ view 바뀔 때마다 기존 raw 데이터 포맷만 다시 적용
     useEffect(() => {
         setRefinedSchedules(refineTeamSchedule(rawSchedules, currentView));
-    }, [currentView, rawSchedules, refineTeamSchedule]);
-
-    const dayPropGetter = (date) => {
-        const day = date.getDay();
-        const isToday = format(date, 'yyyy-MM-dd') === format(new Date(), 'yyyy-MM-dd');
-        const isCurrentMonth = date.getMonth() === new Date().getMonth();
-
-        const style = {
-            backgroundColor: isCurrentMonth ? 'transparent' : '#efefef',
-            color: isCurrentMonth ? 'inherit' : '#ccc', // 이번 달 아니면 흐리게
-        };
-
-        // 👉 요일 색상은 이번 달일 때만 적용
-        if (isCurrentMonth) {
-            if (day === 0) {
-                style.backgroundColor = '#fff5f5'; // 일요일
-            } else if (day === 6) {
-                style.backgroundColor = '#f0f8ff'; // 토요일
-            }
-        }
-
-        // 👉 오늘은 최우선으로 덮어씌우기
-        if (isToday) {
-            style.backgroundColor = '#fff3d7';  // 오늘 배경
-            style.fontWeight = 'bold';
-            style.color = '#333';
-            style.border = '1px solid #aaa';
-            style.borderRadius = '4px';
-        }
-
-        return { style };
-    };
-
+    }, [rawSchedules, refineTeamSchedule, currentView]);
 
     return (
         <div>
             <Calendar
                 localizer={localizer}
                 formats={formats}
-                events={events || refinedSchedules}
+                events={events || refinedSchedules}  // 이벤트 데이터는 상태에 따라 조정됨
                 startAccessor="start"
                 endAccessor="end"
                 defaultView="month"
                 onView={(view) => setCurrentView(view)}
                 views={['month', 'week', 'day']}
                 style={{ height: '100%' }}
-                // dayPropGetter={dayPropGetter}
+                eventPropGetter={(event, start, end, isSelected) => {
+                    const isFavoriteMatch = event.teams?.some(code =>
+                        favoriteTeamCodes?.includes(code)
+                    );
+
+                    const isUnstarted = event.state === 'unstarted';
+
+                    let style;
+
+                    // 🎯 즐겨찾기 팀 경기의 색상 스타일
+                    if (isFavoriteMatch) {
+                        style = {
+                            backgroundColor: '#f4511e', // 강조 색상 (주황색)
+                            border: '1px solid #d84315',
+                            color: '#fffaf0',
+                            fontWeight: '600',
+                        };
+                    }
+                    // ⏳ 시작 안 한 경기 스타일
+                    else if (isUnstarted) {
+                        style = {
+                            backgroundColor: '#e3f2fd', // 연블루
+                            border: '1px dashed #64b5f6',
+                            color: '#1e88e5',
+                            fontStyle: 'italic',
+                        };
+                    }
+                    // 🕓 일반 종료 경기 스타일
+                    else {
+                        style = {
+                            backgroundColor: '#f0f2f5',
+                            border: '1px solid #cfd8dc',
+                            color: '#37474f',
+                        };
+                    }
+
+                    // 📦 공통 스타일 추가
+                    style.borderRadius = '6px';
+                    style.padding = '2px 6px';
+
+                    return { style };
+                }}
                 components={{
                     toolbar: CustomToolbar,
                     eventWrapper: CustomEventWrapper,

--- a/src/utils/api-lol.js
+++ b/src/utils/api-lol.js
@@ -1,12 +1,36 @@
+export async function fetchFavoriteTeam() {
+    const response = await fetch('/api/lol/favorites', {
+        method: "GET",
+        credentials: "include",
+    });
 
-export async function getFavoritTeamSchedule() {
-    const favoriteTeamCode = 'T1';
+    if (!response.ok) {
+        throw new Error(await response.text());
+    }
+
+    return await response.json();
+}
+
+export async function getFavoritTeamSchedule(favoriteTeamCode) {
     const response = await fetch(`/api/lol/comps/${favoriteTeamCode}`, {
         method: 'GET',
     });
 
     if (!response.ok) {
         throw new Error('즐겨찾는 팀 일정 조회 실패');
+    }
+
+    return await response.json();
+}
+
+export async function getAllSchedules() {
+    const response = await fetch('/api/lol/comps', {
+        method: 'GET',
+        credentials: 'include'
+    });
+
+    if (!response.ok) {
+        throw new Error('전체 경기 일정 조회 실패');
     }
 
     return await response.json();


### PR DESCRIPTION
- 전체 일정 조회 API 연동
- 로그인 후 즐겨찾는 팀 경기 스타일 다르게 적용
- 코드 정리 및 설명 주석 추가
- 불필요한 코드 제거