### PR TITLE
feat: 팀 즐겨찾기 및 경기 필터링 기능 구현 + CSRF 대응 적용

### DIFF
--- a/src/app/page.js
+++ b/src/app/page.js
@@ -6,6 +6,7 @@ import "@/styles/css/chat.css";
 import { useAuth } from "@/context/AuthContext.js";
 import { useRouter } from "next/navigation";
 import MyCalendar from "@components/MyCalendar.js";
+import {CalandarProvider} from "@/context/CalandarContext.js";
 
 
 export default function Home({ Component, pageProps }) {
@@ -20,7 +21,9 @@ export default function Home({ Component, pageProps }) {
 
     return (
         <main className="home-container">
-            <MyCalendar />
+            <CalandarProvider>
+                <MyCalendar />
+            </CalandarProvider>
 
             {/* 로그인 여부에 따라 버튼을 감싸서 Chat 표시 */}
             {userId ? (

--- a/src/components/CustomEventWrapper.js
+++ b/src/components/CustomEventWrapper.js
@@ -6,6 +6,8 @@ import { format } from 'date-fns';
  * 일정 클릭 팝업 이벤트
  */
 const CustomEventWrapper = ({ event, children }) => {
+    const teamCodes = event.participants?.map(team => team.teamCode);
+
     return (
         <Popup
             trigger={<div>{children}</div>}
@@ -23,12 +25,16 @@ const CustomEventWrapper = ({ event, children }) => {
             }}
         >
             <div className="text-sm">
-                {/*<div><strong>{event.teams.join(' vs ')}</strong></div>*/}
-                <div><strong>{event.teams
-                    .map(teamCode => {
-                        return event.winner === teamCode ? teamCode + '(승)' : teamCode;
-                    })
-                    .join(' vs ')}</strong></div>
+                <div>
+                    <strong>{teamCodes
+                        .map(teamCode => {
+                            return event.winningTeamCode === teamCode
+                                ? teamCode + '(승)'
+                                : teamCode;
+                        })
+                        .join(' vs ')}
+                    </strong>
+                </div>
                 <div>{format(new Date(event.start), 'yyyy년 M월 d일 HH:mm')}</div>
                 {/*<div>경기 ID: {event.id}</div>*/}
                 {/* 필요 시 버튼도 추가 가능 */}

--- a/src/components/FavoriteTeamButton.js
+++ b/src/components/FavoriteTeamButton.js
@@ -1,0 +1,93 @@
+import { useEffect, useState } from 'react';
+import { FaStar, FaRegStar } from 'react-icons/fa';
+import { useCalandar } from "@/context/CalandarContext.js";
+import { apiAddFavoriteTeam, apiRemoveFavoriteTeam } from "@utils/api-lol.js";
+import { useAuth } from "@/context/AuthContext.js";  // userId가 있는 곳
+
+const FavoriteTeamButton = ({ teamId, teamCode, teamName, slug, image }) => {
+    const { userId } = useAuth(); // userId 가져오기
+    const { selectedTeam, setSelectedTeam, favoriteTeamCodes, setFavoriteTeamCodes } = useCalandar(); // ⬅️ context에서 함수 가져오기
+    const [hovered, setHovered] = useState(false); // 버튼 개별 상태
+    const [isFavorited, setIsFavorited] = useState(favoriteTeamCodes.includes(teamCode));
+
+    useEffect(() => {
+        setIsFavorited(favoriteTeamCodes.includes(teamCode));
+    }, [favoriteTeamCodes, teamCode]);
+
+    // 즐겨찾기 토글 핸들러
+    const handleFavoriteToggle = async () => {
+        if (!userId) {
+            console.warn('사용자가 로그인하지 않았습니다.');
+            return;  // 인증되지 않으면 즐겨찾기 기능을 수행하지 않음
+        }
+
+        const isAlreadyFavorited = favoriteTeamCodes.includes(teamCode);
+
+        // csrf 토큰 발급
+        await fetch('/api/csrf', { method: 'GET', credentials: 'include' });
+
+        try {
+            if (isAlreadyFavorited) {
+                await apiRemoveFavoriteTeam(teamId); // 즐겨찾기 해제
+            } else {
+                await apiAddFavoriteTeam(teamId);    // 즐겨찾기 추가
+            }
+
+            setIsFavorited(!isFavorited);
+
+            // UI 상태 업데이트
+            setFavoriteTeamCodes((prevFavorites) => {
+                return isAlreadyFavorited
+                    ? prevFavorites.filter((code) => code !== teamCode)
+                    : [teamCode, ...prevFavorites];
+            });
+        } catch (error) {
+            console.error("즐겨찾기 토글 실패:", error);
+        }
+    };
+
+    // 팀 선택 버튼 (해당 팀 경기 일정 하이라이트)
+    const handleTeamBtnClick = () => {
+        setSelectedTeam({ teamCode, teamName, slug }); // 선택한 팀 정보 저장
+    };
+
+    return (
+        <div className="relative inline-block">
+            {/* ⭐ 별 아이콘 버튼으로 만들어 클릭 가능하게 */}
+            {userId && ( // 로그인한 사용자일 때만 즐겨찾기 버튼 표시
+                <button
+                    className="star-wrapper"
+                    onClick={(e) => {
+                        e.stopPropagation(); // 부모 버튼 클릭 방지
+                        handleFavoriteToggle();  // 즐겨찾기 토글
+                    }}
+                    title={isFavorited ? '즐겨찾기 해제' : '즐겨찾기 추가'}
+                >
+                    <i className={`star-icon ${isFavorited ? 'active' : 'inactive'} ${hovered ? 'hover' : ''}`}>
+                        {isFavorited ? <FaStar /> : <FaRegStar />}
+                    </i>
+                </button>
+            )}
+
+            {/* ⭕ 동그란 팀 버튼 (로그인 여부와 관계없이 사용 가능) */}
+            <button
+                title={teamName}
+                onClick={handleTeamBtnClick}
+                onMouseEnter={() => setHovered(true)}
+                onMouseLeave={() => setHovered(false)}
+                className={`team-button ${isFavorited ? 'favorited' : ''} 
+                    ${selectedTeam?.teamCode === teamCode ? 'selected' : ''} 
+                    ${hovered ? 'hovered' : ''}`
+                }
+            >
+                <img
+                    src={image}
+                    alt={teamName}
+                    className="team-image"
+                />
+            </button>
+        </div>
+    );
+};
+
+export default FavoriteTeamButton;

--- a/src/components/FavoriteTeamList.js
+++ b/src/components/FavoriteTeamList.js
@@ -1,0 +1,41 @@
+import { useState, useEffect } from 'react';
+import FavoriteTeamButton from "@components/FavoriteTeamButton.js";
+
+const FavoriteTeamList = () => {
+    const [teams, setTeams] = useState([]);
+
+    // 팀 정보 불러오기 (fetch)
+    useEffect(() => {
+        const homeLeague = 'LCK';
+        const fetchTeams = async () => {
+            try {
+                const response = await fetch(`/api/lol/teams?homeLeague=${homeLeague}`, {
+                    method: 'GET'
+                }); // 실제 API URL로 변경 필요
+                const data = await response.json();
+                setTeams(data); // 데이터 설정
+            } catch (error) {
+                console.error("팀 정보를 불러오는 데 실패했습니다.", error);
+            }
+        };
+
+        fetchTeams();
+    }, []);
+
+    return (
+        <div className="team-btn-container">
+            {teams.map((team) => (
+                <FavoriteTeamButton
+                    key={team.id}
+                    teamId={team.id}
+                    teamCode={team.teamCode}
+                    teamName={team.teamName}
+                    slug={team.slug}
+                    image={team.image}
+                />
+            ))}
+        </div>
+    );
+};
+
+export default FavoriteTeamList;

--- a/src/components/MyCalendar.js
+++ b/src/components/MyCalendar.js
@@ -11,6 +11,8 @@ import {fetchFavoriteTeam, getAllSchedules} from '@utils/api-lol.js';
 import CustomToolbar from '@components/CustomToolbar.js';
 import CustomEventWrapper from "@components/CustomEventWrapper.js";
 import { useAuth } from "@/context/AuthContext.js";
+import FavoriteTeamList from "@components/FavoriteTeamList.js";
+import {useCalandar} from "@/context/CalandarContext.js";
 
 const locales = { ko };
 
@@ -36,17 +38,20 @@ const formats = {
 // 로그인 안했으면 전체 일정 조회
 const MyCalendar = ({ events }) => {
     const { userId } = useAuth();
+    const { selectedTeam, favoriteTeamCodes, setFavoriteTeamCodes } = useCalandar();
     const [currentView, setCurrentView] = useState('month');
-    const [favoriteTeamCodes, setFavoriteTeamCodes] = useState([]);
     const [rawSchedules, setRawSchedules] = useState([]);
     const [refinedSchedules, setRefinedSchedules] = useState([]);
 
+    // FIXME 즐겨찾기 여러개 가능하게
     useEffect(() => {
         const fetchSchedule = async () => {
             if (userId) {
                 const data = await fetchFavoriteTeam(); // displayOrder, teamCode, teamName
+                console.log(data.map(team => team.teamCode))
                 setFavoriteTeamCodes(data.map(team => team.teamCode));
             }
+
             setRawSchedules(await getAllSchedules()); // 로그인 여부와 상관없이 전체 일정 조회
         };
 
@@ -58,26 +63,30 @@ const MyCalendar = ({ events }) => {
         if (!schedules) return [];
 
         return view === 'month'
-            ? schedules.map((schedule) => ({
-                ...schedule,
-                title: schedule.teams.join(' vs '),
-                start: new Date(schedule.startTime),
-                end: new Date(schedule.startTime),
-                allDay: true,
-            }))
+            ? schedules.map((schedule) => {
+                const participants = schedule.participants;
+                return {
+                    ...schedule,
+                    title: [participants[0].teamCode, participants[1].teamCode].join(' vs '),
+                    start: new Date(schedule.startTime),
+                    end: new Date(schedule.startTime),
+                    allDay: true
+                }
+            })
             : schedules.flatMap((schedule) => {
+                const participants = schedule.participants;
                 const startTime = new Date(schedule.startTime);
                 return [
                     {
                         ...schedule,
-                        title: schedule.teams.join(' vs '),
+                        title: [participants[0].teamCode, participants[1].teamCode].join(' vs '),
                         start: startTime,
                         end: new Date(startTime.getTime() + 60 * 60 * 1000),
                         allDay: true,
                     },
                     {
                         ...schedule,
-                        title: schedule.teams.join(' vs '),
+                        title: [participants[0].teamCode, participants[1].teamCode].join(' vs '),
                         start: startTime,
                         end: new Date(startTime.getTime() + 60 * 60 * 1000),
                         allDay: false,
@@ -89,7 +98,8 @@ const MyCalendar = ({ events }) => {
     // ✅ view 바뀔 때마다 기존 raw 데이터 포맷만 다시 적용
     useEffect(() => {
         setRefinedSchedules(refineTeamSchedule(rawSchedules, currentView));
-    }, [rawSchedules, refineTeamSchedule, currentView]);
+    }, [rawSchedules, refineTeamSchedule, currentView, selectedTeam]);
+
 
     return (
         <div>
@@ -104,44 +114,55 @@ const MyCalendar = ({ events }) => {
                 views={['month', 'week', 'day']}
                 style={{ height: '100%' }}
                 eventPropGetter={(event, start, end, isSelected) => {
-                    const isFavoriteMatch = event.teams?.some(code =>
-                        favoriteTeamCodes?.includes(code)
+                    // console.log('경기 정보: ', event);
+                    const teamCodes = event.participants?.map(team => team.teamCode);
+                    const isFavoriteMatch = teamCodes.some(teamCode =>
+                        favoriteTeamCodes?.includes(teamCode)
                     );
 
+                    const isSelectedTeamMatch = selectedTeam && teamCodes.includes(selectedTeam.teamCode);
                     const isUnstarted = event.state === 'unstarted';
 
-                    let style;
+                    let style = {
+                        borderRadius: '6px',
+                        padding: '2px 6px',
+                    };
 
-                    // 🎯 즐겨찾기 팀 경기의 색상 스타일
-                    if (isFavoriteMatch) {
-                        style = {
-                            backgroundColor: '#f4511e', // 강조 색상 (주황색)
-                            border: '1px solid #d84315',
-                            color: '#fffaf0',
-                            fontWeight: '600',
-                        };
+                    // 🎯 즐겨찾기 + 선택된 팀 → 더 강조
+                    if (isFavoriteMatch && isSelectedTeamMatch) {
+                        style.backgroundColor = '#f4511e';
+                        style.border = '2px solid #ffd54f';
+                        style.color = '#fffaf0';
+                        style.fontWeight = '600';
+                        style.boxShadow = '0 0 0 2px #ffeb3b66';
                     }
-                    // ⏳ 시작 안 한 경기 스타일
+                    // ⭐ 즐겨찾기만
+                    else if (isFavoriteMatch) {
+                        style.backgroundColor = '#f4511e';
+                        style.border = '1px solid #d84315';
+                        style.color = '#fffaf0';
+                        style.fontWeight = '600';
+                    }
+                    // 🔷 선택된 팀만
+                    else if (isSelectedTeamMatch) {
+                        style.backgroundColor = '#fffde7';
+                        style.border = '2px dashed #1976d2'; // 파란 점선 강조
+                        style.color = '#0d47a1';
+                        style.fontWeight = '500';
+                    }
+                    // ⏳ 시작 안 한 경기
                     else if (isUnstarted) {
-                        style = {
-                            backgroundColor: '#e3f2fd', // 연블루
-                            border: '1px dashed #64b5f6',
-                            color: '#1e88e5',
-                            fontStyle: 'italic',
-                        };
+                        style.backgroundColor = '#e3f2fd';
+                        style.border = '1px dashed #64b5f6';
+                        style.color = '#1e88e5';
+                        style.fontStyle = 'italic';
                     }
-                    // 🕓 일반 종료 경기 스타일
+                    // 🕓 기본 경기
                     else {
-                        style = {
-                            backgroundColor: '#f0f2f5',
-                            border: '1px solid #cfd8dc',
-                            color: '#37474f',
-                        };
+                        style.backgroundColor = '#f0f2f5';
+                        style.border = '1px solid #cfd8dc';
+                        style.color = '#37474f';
                     }
-
-                    // 📦 공통 스타일 추가
-                    style.borderRadius = '6px';
-                    style.padding = '2px 6px';
 
                     return { style };
                 }}
@@ -150,6 +171,8 @@ const MyCalendar = ({ events }) => {
                     eventWrapper: CustomEventWrapper,
                 }}
             />
+
+            <FavoriteTeamList />
         </div>
     );
 };

--- a/src/context/CalandarContext.js
+++ b/src/context/CalandarContext.js
@@ -1,0 +1,35 @@
+"use client";
+
+// src/context/CalandarContext.js
+import React, {createContext, useContext, useEffect, useState} from 'react';
+
+const CalandarContext = createContext({
+    selectedTeam: null, // ✅ 현재 선택된 팀
+    favoriteTeamCodes: [],
+    setSelectedTeam: () => {},
+    setFavoriteTeamCodes: () => {}
+});
+
+export const useCalandar = () => useContext(CalandarContext);
+
+export const CalandarProvider = ({ children }) => {
+    const [selectedTeam, setSelectedTeam] = useState(null);
+    const [favoriteTeamCodes, setFavoriteTeamCodes] = useState([]);
+
+    useEffect(() => {
+        console.log('selectedTeam 변경됨:', selectedTeam);
+    }, [selectedTeam]);
+
+    useEffect(() => {
+        console.log('favoriteTeamCodes 변경됨:', favoriteTeamCodes);
+    }, [favoriteTeamCodes]);
+
+    return (
+        <CalandarContext.Provider value={{
+            selectedTeam, setSelectedTeam,
+            favoriteTeamCodes, setFavoriteTeamCodes
+        }}>
+            {children}
+        </CalandarContext.Provider>
+    );
+};

--- a/src/styles/tailwind/lol/calendar.css
+++ b/src/styles/tailwind/lol/calendar.css
@@ -1,3 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
 /* calendar-tailwind.css */
 .rbc-calendar {
     @apply text-sm font-sans;
@@ -26,3 +30,97 @@
 .rbc-toolbar-label {
     @apply font-bold text-lg;
 }
+
+/**
+    즐겨찾기 버튼
+ */
+.button {
+    @apply flex items-center gap-1 text-sm transition duration-200;
+}
+
+.button-hovered {
+    @apply text-orange-500;
+}
+
+.button-default {
+    @apply text-gray-700;
+}
+
+/* 기본 별 아이콘 색상 */
+.star-icon {
+    transition: color 0.2s ease, transform 0.2s ease;
+}
+
+.star-icon.favorited,
+.star-icon.hovered {
+    color: #fbbf24; /* yellow-400 */
+}
+
+.star-icon.not-favorited {
+    color: #9ca3af; /* gray-400 */
+}
+
+/* Hovered 상태일 때 아이콘 확대 */
+.star-icon.hovered {
+    transform: scale(1.1);
+}
+
+
+/* 팀별 아이콘 버튼 스타일  */
+.team-btn-container{
+    @apply flex gap-3 overflow-x-auto px-2 py-3;
+    scroll-snap-type: x mandatory;
+    -webkit-overflow-scrolling: touch; /* 부드러운 스크롤 (iOS) */
+}
+
+.team-btn-container::-webkit-scrollbar {
+    display: none; /* 스크롤바 숨김 */
+}
+
+.team-button {
+    @apply w-10 h-10 flex items-center justify-center rounded-full border-2 transition-all duration-300 overflow-hidden;
+    flex: 0 0 auto; /* 크기 고정, 줄어들지 않도록 */
+    background-color: #333333;
+}
+
+.team-button.selected {
+    background-color: #dedede;
+}
+
+.team-button.favorited {
+    @apply border-yellow-500;
+}
+
+.team-button:not(.favorited) {
+    @apply border-gray-300;
+}
+
+.team-button.hovered {
+    background-color: #dedede;
+}
+
+.team-image {
+    @apply w-6 h-6 object-contain;
+}
+
+.favorite-icon {
+    @apply absolute top-0 left-0 p-1;
+}
+
+.star-wrapper {
+    @apply absolute -top-2 -left-2 z-10 p-1 bg-white rounded-full;
+    cursor: pointer;
+}
+.star-icon {
+    @apply text-lg transition-transform duration-150;
+}
+.star-icon.active {
+    @apply text-yellow-400;
+}
+.star-icon.inactive {
+    @apply text-gray-400;
+}
+.star-icon.hover {
+    @apply scale-110;
+}
+

--- a/src/utils/api-lol.js
+++ b/src/utils/api-lol.js
@@ -1,3 +1,12 @@
+// 쿠키에서 특정 이름을 가진 값을 가져오는 함수
+function getCookie(name) {
+    const value = `; ${document.cookie}`;
+    const parts = value.split(`; ${name}=`);
+    if (parts.length === 2) return parts.pop().split(';').shift();
+    return null; // 쿠키가 없으면 null을 반환
+}
+
+
 export async function fetchFavoriteTeam() {
     const response = await fetch('/api/lol/favorites', {
         method: "GET",
@@ -11,16 +20,36 @@ export async function fetchFavoriteTeam() {
     return await response.json();
 }
 
-export async function getFavoritTeamSchedule(favoriteTeamCode) {
-    const response = await fetch(`/api/lol/comps/${favoriteTeamCode}`, {
-        method: 'GET',
+export async function apiAddFavoriteTeam(teamId) {
+    const csrfToken = getCookie("XSRF-TOKEN");
+    const response = await fetch(`/api/lol/favorites/${teamId}`, {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json",
+            "X-XSRF-TOKEN": csrfToken,
+        },
+        credentials: "include",
     });
 
     if (!response.ok) {
-        throw new Error('즐겨찾는 팀 일정 조회 실패');
+        throw new Error(await response.text());
     }
+}
 
-    return await response.json();
+export async function apiRemoveFavoriteTeam(teamId) {
+    const csrfToken = getCookie("XSRF-TOKEN");
+    const response = await fetch(`/api/lol/favorites/${teamId}`, {
+        method: "DELETE",
+        headers: {
+            "Content-Type": "application/json",
+            "X-XSRF-TOKEN": csrfToken,
+        },
+        credentials: "include",
+    });
+
+    if (!response.ok) {
+        throw new Error(await response.text());
+    }
 }
 
 export async function getAllSchedules() {
@@ -31,6 +60,18 @@ export async function getAllSchedules() {
 
     if (!response.ok) {
         throw new Error('전체 경기 일정 조회 실패');
+    }
+
+    return await response.json();
+}
+
+export async function getFavoritTeamSchedule(favoriteTeamCode) {
+    const response = await fetch(`/api/lol/comps/${favoriteTeamCode}`, {
+        method: 'GET',
+    });
+
+    if (!response.ok) {
+        throw new Error('즐겨찾는 팀 일정 조회 실패');
     }
 
     return await response.json();


### PR DESCRIPTION
1. feat: 팀 즐겨찾기 기능
- 즐겨찾기 등록/해제 UI 및 API 연동
- 로그인한 사용자만 즐겨찾기 가능하도록 처리
- 선택된 팀 스타일 및 상태 관리 개선

2. feat: 경기 일정 필터링 기능
- 팀별 일정 필터링 기능 구현
- 선택한 팀에 따라 경기 일정 동적 렌더링
- 팀 선택 시 UI 하이라이트 및 일정 연동

3. feat: CSRF 토큰 수동 발급 및 요청 시 자동 포함 처리
- 인증이 필요한 요청 전에 /api/csrf 호출하여 토큰 발급
- 이후 API 요청 시 CSRF 토큰을 헤더에 자동 포함되도록 설정
- 즐겨찾기 토글 등 보안 요청에서 CSRF 대응 완료