### PR TITLE
1. [Feat] 토너먼트 순위 조회 UI 및 nav 스크롤 연동 기능 추가

### DIFF
--- a/src/app/page.js
+++ b/src/app/page.js
@@ -1,37 +1,90 @@
-"use client"
+"use client";
 
-// app/page.js
 import Chat from "@/components/Chat";
-import "@/styles/css/chat.css";
 import { useAuth } from "@/context/AuthContext.js";
 import { useRouter } from "next/navigation";
 import MyCalendar from "@components/MyCalendar.js";
-import {CalandarProvider} from "@/context/CalandarContext.js";
-
+import { CalandarProvider } from "@/context/CalandarContext.js";
+import Standings from "@components/Standings.js";
+import { useEffect, useState } from "react";
+import { apiFetchTournaments } from "@utils/api-lol.js";
+import Loading from "@components/Loading.js";
+import "@/styles/css/chat.css";
+import "@/styles/css/standings.css";
 
 export default function Home({ Component, pageProps }) {
     const { userId } = useAuth();
     const router = useRouter();
 
+    const [tournaments, setTournaments] = useState([]);
+    const [activeTournamentId, setActiveTournamentId] = useState('');
+    const [isLoading, setIsLoading] = useState(true); // ✅ 로딩 상태 추가
+
+    useEffect(() => {
+        const fetchTournaments = async () => {
+            setIsLoading(true); // ✅ 로딩 시작
+            const response = await apiFetchTournaments();
+            setTournaments(response);
+            if (response.length > 0) {
+                const ongoingTournament = response.find(data => data.active);
+                setActiveTournamentId(ongoingTournament ? ongoingTournament.id : response[0].id);
+            }
+            setIsLoading(false); // ✅ 로딩 끝
+        };
+        fetchTournaments();
+    }, []);
+
     const handleChatBtnClick = () => {
-        // React의 클라이언트 사이드 네비게이션을 사용해 페이지를 변경
-        // 전체 페이지 새로고침 없이, SPA(Single Page Application) 방식으로 이동
         router.push("/auth/login");
-    }
+    };
+
+    const handleTournamentBtnClick = (tournamentId) => {
+        setActiveTournamentId(tournamentId);
+    };
 
     return (
         <main className="home-container">
-            <CalandarProvider>
-                <MyCalendar />
-            </CalandarProvider>
+            <div className="section" id="section1">
+                <CalandarProvider>
+                    <MyCalendar />
+                </CalandarProvider>
+            </div>
 
-            {/* 로그인 여부에 따라 버튼을 감싸서 Chat 표시 */}
+            <div className="section" id="section2">
+                {isLoading ? (
+                    <Loading message="토너먼트 불러오는 중..." />
+                ) : (
+                    <div className="tournament-container">
+                        <div className="tournament-select-wrapper">
+                            <span>Standings</span>
+                            <select
+                                className="tournament-select"
+                                value={activeTournamentId}
+                                onChange={(e) => handleTournamentBtnClick(e.target.value)}
+                            >
+                                {tournaments.map(t => (
+                                    <option
+                                        key={t.id}
+                                        value={t.id}
+                                        title={`${t.startDate} ~ ${t.endDate}`}
+                                    >
+                                        {t.slug}
+                                    </option>
+                                ))}
+                            </select>
+                        </div>
+                        <Standings tournamentId={activeTournamentId} />
+                    </div>
+                )}
+            </div>
+
             {userId ? (
                 <Chat />
             ) : (
-                <button onClick={ handleChatBtnClick }
-                        className="chat-toggle-button"
-                        title="로그인 필요"
+                <button
+                    onClick={handleChatBtnClick}
+                    className="chat-toggle-button"
+                    title="로그인 필요"
                 >
                     🔒
                 </button>
@@ -39,4 +92,3 @@ export default function Home({ Component, pageProps }) {
         </main>
     );
 }
-

--- a/src/components/CustomToolbar.js
+++ b/src/components/CustomToolbar.js
@@ -1,13 +1,9 @@
 import React from 'react';
-import { FaChevronLeft, FaChevronRight, FaCalendarDay, FaCalendarWeek, FaCalendarAlt } from 'react-icons/fa';
-import { addDays, startOfWeek, format } from 'date-fns';
-import { ko } from 'date-fns/locale';
+import {FaCalendarAlt, FaCalendarDay, FaChevronLeft, FaChevronRight} from 'react-icons/fa';
+import {format} from 'date-fns';
 
-const formatWeekRange = (date) => {
-    const start = startOfWeek(date, { weekStartsOn: 1 }); // 월요일 시작
-    const end = addDays(start, 6);
-    return `${format(start, 'yyyy년 M월 d일', { locale: ko })} ~ ${format(end, 'M월 d일', { locale: ko })}`;
-};
+const years = Array.from({ length: 10 }, (_, i) => new Date().getFullYear() - 5 + i);
+const months = Array.from({ length: 12 }, (_, i) => i + 1);
 
 const CustomToolbar = (toolbar) => {
     const goToBack = () => toolbar.onNavigate('PREV');
@@ -15,22 +11,51 @@ const CustomToolbar = (toolbar) => {
     const goToToday = () => toolbar.onNavigate('TODAY');
     const goToView = (view) => toolbar.onView(view);
 
-    const label =
-        toolbar.view === 'week'
-            ? formatWeekRange(toolbar.date)
-            : format(toolbar.date, 'yyyy년 M월', { locale: ko });
+    const handleYearChange = (e) => {
+        const newDate = new Date(toolbar.date);
+        newDate.setFullYear(parseInt(e.target.value));
+        toolbar.onNavigate('DATE', newDate);
+    };
+
+    const handleMonthChange = (e) => {
+        const newDate = new Date(toolbar.date);
+        newDate.setMonth(parseInt(e.target.value) - 1); // 0-indexed
+        toolbar.onNavigate('DATE', newDate);
+    };
 
     return (
         <div className="custom-toolbar">
             <div className="label-area">
                 <button onClick={goToBack}><FaChevronLeft /></button>
-                <span>{label}</span>
+                <div className="date-selectors">
+                    {toolbar.view === 'month' && (
+                        <>
+                            <select value={toolbar.date.getFullYear()} onChange={handleYearChange}>
+                                {years.map((year) => (
+                                    <option key={year} value={year}>{year}년</option>
+                                ))}
+                            </select>
+                            <select value={toolbar.date.getMonth() + 1} onChange={handleMonthChange}>
+                                {months.map((month) => (
+                                    <option key={month} value={month}>{month}월</option>
+                                ))}
+                            </select>
+                        </>
+                    )}
+                    {(toolbar.view === 'week' || toolbar.view === 'day') && (
+                        <input
+                            type="date"
+                            value={format(toolbar.date, 'yyyy-MM-dd')}
+                            onChange={(e) => toolbar.onNavigate('DATE', new Date(e.target.value))}
+                        />
+                    )}
+                </div>
                 <button onClick={goToNext}><FaChevronRight /></button>
             </div>
-            <div>
+            <div className="toolbar-controls">
                 <button onClick={goToToday}>Today</button>
                 <button onClick={() => goToView('month')}><FaCalendarAlt /></button>
-                <button onClick={() => goToView('week')}><FaCalendarWeek /></button>
+                {/*<button onClick={() => goToView('week')}><FaCalendarWeek /></button>*/}
                 <button onClick={() => goToView('day')}><FaCalendarDay /></button>
             </div>
         </div>

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,13 +1,43 @@
 "use client";
 
-import { useEffect } from "react";
-import { useAuth } from "@/context/AuthContext.js";  // useAuth 훅을 사용
-import UserInfo from "./UserInfo.js";  // UserInfo 컴포넌트
+import {useAuth} from "@/context/AuthContext.js"; // useAuth 훅을 사용
+import UserInfo from "./UserInfo.js"; // UserInfo 컴포넌트
 import LoginLink from "./LoginLink.js"; // LoginLink 컴포넌트
 import Link from 'next/link';
+import {usePathname} from "next/navigation.js";
+import {useEffect, useState} from "react";
 
 export default function Header() {
     const { username, expirationTime } = useAuth();  // AuthContext에서 값 가져오기
+    const pathname = usePathname();
+    const isMainPage = pathname === "/";
+    const [activeSection, setActiveSection] = useState('');
+
+    const handleClick = (sectionId) => {
+        setActiveSection(sectionId);
+    };
+
+    useEffect(() => {
+        const sections = document.querySelectorAll('div.section');
+
+        const observer = new IntersectionObserver(
+            (entries) => {
+                entries.forEach((entry) => {
+                    if (entry.isIntersecting && activeSection !== entry.target.id) {
+                        setActiveSection(entry.target.id);
+                    }
+                });
+            },
+            { rootMargin: '-50% 0px -50% 0px', threshold: 0 } // 중앙 기준
+        );
+
+        sections.forEach((section) => observer.observe(section));
+
+        return () => {
+            sections.forEach((section) => observer.unobserve(section));
+        };
+    }, []);
+
 
     return (
         <header>
@@ -28,6 +58,22 @@ export default function Header() {
                     )}
                 </div>
             </div>
+            {/*메인페이지인 경우에만 nav 표시*/}
+            { isMainPage &&
+                <div className="nav-container">
+                    <nav>
+                        <ul>
+                            <li className={activeSection === 'section1' ? 'active' : ''}>
+                                <a href="#section1" onClick={() => handleClick('section1')}>일정</a>
+                            </li>
+                            <li className={activeSection === 'section2' ? 'active' : ''}>
+                                <a href="#section2" onClick={() => handleClick('section2')}>순위</a>
+                            </li>
+                        </ul>
+                    </nav>
+                </div>
+            }
+
         </header>
     );
 }

--- a/src/components/Loading.js
+++ b/src/components/Loading.js
@@ -1,0 +1,14 @@
+// components/Loading.js
+import React from "react";
+import "@/styles/css/loading.css"; // 스피너 스타일 따로 분리 (아래에 추가됨)
+
+const Loading = ({ message = "로딩 중..." }) => {
+    return (
+        <div className="loading-wrapper">
+            <div className="spinner" />
+            <p>{message}</p>
+        </div>
+    );
+};
+
+export default Loading;

--- a/src/components/MyCalendar.js
+++ b/src/components/MyCalendar.js
@@ -39,11 +39,11 @@ const formats = {
 const MyCalendar = ({ events }) => {
     const { userId } = useAuth();
     const { selectedTeam, favoriteTeamCodes, setFavoriteTeamCodes } = useCalandar();
+    const [currentDate, setCurrentDate] = useState(new Date());
     const [currentView, setCurrentView] = useState('month');
     const [rawSchedules, setRawSchedules] = useState([]);
     const [refinedSchedules, setRefinedSchedules] = useState([]);
 
-    // FIXME 즐겨찾기 여러개 가능하게
     useEffect(() => {
         const fetchSchedule = async () => {
             if (userId) {
@@ -105,9 +105,63 @@ const MyCalendar = ({ events }) => {
         setRefinedSchedules(refineTeamSchedule(rawSchedules, currentView));
     }, [rawSchedules, refineTeamSchedule, currentView, selectedTeam]);
 
+    // 경기 일정별 스타일
+    const eventPropGetter = (event, start, end, isSelected) => {
+        // console.log('경기 정보: ', event);
+        const teamCodes = event.participants?.map(team => team.teamCode);
+        const isFavoriteMatch = teamCodes.some(teamCode =>
+            favoriteTeamCodes?.includes(teamCode)
+        );
+
+        const isSelectedTeamMatch = selectedTeam && teamCodes.includes(selectedTeam.teamCode);
+        const isUnstarted = event.state === 'unstarted';
+
+        let style = {
+            borderRadius: '6px',
+            padding: '2px 6px',
+        };
+
+        // 🎯 즐겨찾기 + 선택된 팀 → 더 강조
+        if (isFavoriteMatch && isSelectedTeamMatch) {
+            style.backgroundColor = '#f4511e';
+            style.border = '2px solid #ffd54f';
+            style.color = '#fffaf0';
+            style.fontWeight = '600';
+            style.boxShadow = '0 0 0 2px #ffeb3b66';
+        }
+        // ⭐ 즐겨찾기만
+        else if (isFavoriteMatch) {
+            style.backgroundColor = '#f4511e';
+            style.border = '1px solid #d84315';
+            style.color = '#fffaf0';
+            style.fontWeight = '600';
+        }
+        // 🔷 선택된 팀만
+        else if (isSelectedTeamMatch) {
+            style.backgroundColor = '#fffde7';
+            style.border = '2px dashed #1976d2'; // 파란 점선 강조
+            style.color = '#0d47a1';
+            style.fontWeight = '500';
+        }
+        // ⏳ 시작 안 한 경기
+        else if (isUnstarted) {
+            style.backgroundColor = '#e3f2fd';
+            style.border = '1px dashed #64b5f6';
+            style.color = '#1e88e5';
+            style.fontStyle = 'italic';
+        }
+        // 🕓 기본 경기
+        else {
+            style.backgroundColor = '#f0f2f5';
+            style.border = '1px solid #cfd8dc';
+            style.color = '#37474f';
+        }
+
+        return { style };
+    }
 
     return (
-        <div>
+        <div className="calandar-container">
             <Calendar
                 localizer={localizer}
                 formats={formats}
@@ -118,63 +172,14 @@ const MyCalendar = ({ events }) => {
                 onView={(view) => setCurrentView(view)}
                 views={['month', 'week', 'day']}
                 style={{height: 'calc(100% - 70px)'}}
-                eventPropGetter={(event, start, end, isSelected) => {
-                    // console.log('경기 정보: ', event);
-                    const teamCodes = event.participants?.map(team => team.teamCode);
-                    const isFavoriteMatch = teamCodes.some(teamCode =>
-                        favoriteTeamCodes?.includes(teamCode)
-                    );
-
-                    const isSelectedTeamMatch = selectedTeam && teamCodes.includes(selectedTeam.teamCode);
-                    const isUnstarted = event.state === 'unstarted';
-
-                    let style = {
-                        borderRadius: '6px',
-                        padding: '2px 6px',
-                    };
-
-                    // 🎯 즐겨찾기 + 선택된 팀 → 더 강조
-                    if (isFavoriteMatch && isSelectedTeamMatch) {
-                        style.backgroundColor = '#f4511e';
-                        style.border = '2px solid #ffd54f';
-                        style.color = '#fffaf0';
-                        style.fontWeight = '600';
-                        style.boxShadow = '0 0 0 2px #ffeb3b66';
-                    }
-                    // ⭐ 즐겨찾기만
-                    else if (isFavoriteMatch) {
-                        style.backgroundColor = '#f4511e';
-                        style.border = '1px solid #d84315';
-                        style.color = '#fffaf0';
-                        style.fontWeight = '600';
-                    }
-                    // 🔷 선택된 팀만
-                    else if (isSelectedTeamMatch) {
-                        style.backgroundColor = '#fffde7';
-                        style.border = '2px dashed #1976d2'; // 파란 점선 강조
-                        style.color = '#0d47a1';
-                        style.fontWeight = '500';
-                    }
-                    // ⏳ 시작 안 한 경기
-                    else if (isUnstarted) {
-                        style.backgroundColor = '#e3f2fd';
-                        style.border = '1px dashed #64b5f6';
-                        style.color = '#1e88e5';
-                        style.fontStyle = 'italic';
-                    }
-                    // 🕓 기본 경기
-                    else {
-                        style.backgroundColor = '#f0f2f5';
-                        style.border = '1px solid #cfd8dc';
-                        style.color = '#37474f';
-                    }
-
-                    return { style };
-                }}
+                eventPropGetter={eventPropGetter}
                 components={{
                     toolbar: CustomToolbar,
                     eventWrapper: CustomEventWrapper,
                 }}
+                selectable
+                date={currentDate}
+                onNavigate={(date) => setCurrentDate(date)}
             />
 
             <FavoriteTeamList />

--- a/src/components/Standings.js
+++ b/src/components/Standings.js
@@ -1,0 +1,89 @@
+import React, { useEffect, useState } from 'react';
+import { apiFetchStandings } from "@utils/api-lol.js";
+import Loading from "@components/Loading.js";
+
+const Standings = ({ tournamentId }) => {
+    const [stages, setStages] = useState([]);
+    const [activeStageId, setActiveStageId] = useState('');
+    const [isLoading, setIsLoading] = useState(true);
+
+    useEffect(() => {
+        const fetchData = async () => {
+            if (!tournamentId) return;
+            setIsLoading(true);
+            const response = await apiFetchStandings(tournamentId);
+            setStages(response);
+            setIsLoading(false);
+        };
+        fetchData();
+    }, [tournamentId]);
+
+    useEffect(() => {
+        if (stages.length > 0) {
+            setActiveStageId(stages[0].id);
+        }
+    }, [stages]);
+
+    const activeStage = stages.find(stage => stage.id === activeStageId);
+
+    if (isLoading) {
+        return <Loading message="순위 데이터를 불러오는 중입니다..." />;
+    }
+
+    if (!activeStage) {
+        return <div className="no-ranking">표시할 순위 정보가 없습니다.</div>;
+    }
+
+    return (
+        <div className="ranking-container">
+            {tournamentId && (
+                <div className="stage-buttons">
+                    {stages.map(stage => (
+                        <button
+                            key={stage.id}
+                            onClick={() => setActiveStageId(stage.id)}
+                            className={activeStageId === stage.id ? 'active' : ''}
+                        >
+                            {stage.name}
+                        </button>
+                    ))}
+                </div>
+            )}
+
+            {activeStage.rankings?.length > 0 ? (
+                <div className="ranking-grid">
+                    {activeStage.rankings.map((team) => {
+                        const [wins, losses] = team.record.split(',');
+
+                        return (
+                            <div className="team-card" key={team.teamId}>
+                                <div className="team-rank-badge">
+                                    <span>{team.rank}</span>
+                                    {activeStage.rankings.filter(t => t.rank === team.rank).length > 1
+                                        && <span> 공동</span>
+                                    }
+                                </div>
+                                <div className="team-icon">
+                                    <img src={team.image} alt={team.teamName} />
+                                </div>
+                                <div className="team-info">
+                                    <div className="team-name">{team.teamCode}</div>
+                                    <div className="team-record">
+                                        <span className="win">승: {wins}</span>
+                                        <span className="loss">패: {losses}</span>
+                                        {/*TODO*/}
+                                        <span>득실: 10</span>
+                                    </div>
+                                </div>
+                            </div>
+                        );
+                    })}
+                </div>
+            ) : (
+                <div className="no-ranking">순위 정보가 없습니다.</div>
+            )}
+        </div>
+    );
+};
+
+export default Standings;

--- a/src/styles/css/loading.css
+++ b/src/styles/css/loading.css
@@ -1,0 +1,26 @@
+/* styles/css/loading.css */
+.loading-wrapper {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    height: 200px;
+    color: #333;
+    font-size: 1.2rem;
+}
+
+.spinner {
+    width: 40px;
+    height: 40px;
+    border: 4px solid #ccc;
+    border-top-color: #0070f3;
+    border-radius: 50%;
+    animation: spin 0.8s linear infinite;
+    margin-bottom: 12px;
+}
+
+@keyframes spin {
+    to {
+        transform: rotate(360deg);
+    }
+}

--- a/src/styles/css/lol-calendar.css
+++ b/src/styles/css/lol-calendar.css
@@ -7,6 +7,7 @@
     width: 700px;
     height: 75%;
     margin: auto;
+    margin-top: 145px;
 }
 
 .home-container > div:not(.chat-container) {
@@ -17,6 +18,7 @@
     .home-container {
         width: 90%;
         height: 75%;
+        margin-top: 170px;
     }
 
 }
@@ -45,12 +47,14 @@
     align-items: center;
     margin-top: 5px;
     margin-bottom: 10px;
+    gap: 0.5rem;
 }
 
 @media (max-width: 500px) {
     .custom-toolbar {
         display: inline-grid;
         justify-content: center;
+        gap: 0.5rem;
     }
 }
 
@@ -80,17 +84,45 @@
     height: fit-content;
 }
 
+.calandar-container {
+    height: 100%;
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 20px;
+    background-color: #f9f9f9;
+    border-radius: 10px;
+    box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+}
 
-/*.rbc-event-content {*/
-/*    pointer-events: none;*/
-/*}*/
+.calandar-container .rbc-calendar .date-selectors select {
+    width: 100%;
+    max-width: fit-content;
+    padding: 5px 25px 5px 10px;
+    font-size: 12px;
+    border: 1px solid #ccc;
+    border-radius: 8px;
+    background-color: #fff;
+    color: #333;
+    appearance: none;
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    background-image: url("data:image/svg+xml;charset=UTF-8,%3Csvg width='12' height='8' viewBox='0 0 12 8' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M6 8L0.803848 0.5H11.1962L6 8Z' fill='%23999'/%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+    background-position: right 8px center;
+    background-size: 12px;
+    transition: border-color 0.3s ease;
+}
 
+.calandar-container .rbc-calendar .date-selectors select:not(:last-child) {
+    margin-right: 3px;
+}
 
-/**
-    reactjs popup style
- */
-/*.popup-content {
-    max-width: 90vw;
-    max-height: 90vh;
-    overflow: auto;
-}*/
+.calandar-container .rbc-calendar .date-selectors select:hover {
+    cursor: pointer;
+}
+
+.calandar-container .rbc-calendar .date-selectors select:focus {
+    border-color: #ff5722;
+    outline: none;
+    box-shadow: 0 0 0 2px rgba(255, 87, 34, 0.2);
+}

--- a/src/styles/css/standings.css
+++ b/src/styles/css/standings.css
@@ -1,0 +1,269 @@
+
+
+/**
+스탠딩 영역
+ */
+.ranking-container {
+    padding: 1rem;
+}
+
+.ranking-grid {
+    display: grid;
+    gap: 1rem;
+}
+
+@media (min-width: 500px) {
+    .ranking-grid {
+        grid-template-columns: repeat(2, 1fr);
+    }
+}
+
+@media (max-width: 499px) {
+    .ranking-grid {
+        grid-template-columns: 1fr;
+    }
+}
+
+.team-card {
+    border: 1px solid #eee;
+    padding: 0.75rem;
+    border-radius: 8px;
+    text-align: center;
+    background: #fafafa;
+}
+
+.team-card img {
+    height: 45px;
+}
+
+.team-rank {
+    font-weight: bold;
+    font-size: 16px;
+}
+
+.team-name {
+    font-size: 14px;
+    margin: 0.5rem 0;
+}
+
+.team-record {
+    font-size: 12px;
+    color: #666;
+}
+
+.no-ranking {
+    padding: 1rem;
+    text-align: center;
+    color: #999;
+}
+
+/**
+
+ */
+/* 전체 컨테이너 스타일 */
+.tournament-container {
+    max-width: 1200px; /* 최대 너비 제한 */
+    margin: 0 auto;
+    padding: 20px;
+    background-color: #f9f9f9; /* 배경색 */
+    border-radius: 10px;
+    box-shadow: 0 0 10px rgba(0, 0, 0, 0.1); /* 부드러운 그림자 */
+}
+
+/* 토너먼트 셀렉트박스 스타일 */
+.tournament-select-wrapper {
+    margin-bottom: 10px;
+    text-align: end;
+    justify-content: space-between;
+    display: flex;
+    align-items: center;
+}
+.tournament-select-wrapper span {
+    font-weight: bold;
+    font-size: 15px;
+    padding: 0 15px;
+}
+
+.tournament-select-wrapper .tournament-select {
+    width: 100%;
+    max-width: fit-content;
+    padding: 7px 39px 7px 15px;
+    font-size: 14px;
+    border: 1px solid #ccc;
+    border-radius: 8px;
+    background-color: #fff;
+    color: #333;
+    appearance: none;
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    background-image: url("data:image/svg+xml;charset=UTF-8,%3Csvg width='12' height='8' viewBox='0 0 12 8' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M6 8L0.803848 0.5H11.1962L6 8Z' fill='%23999'/%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+    background-position: right 12px center;
+    background-size: 12px;
+    transition: border-color 0.3s ease;
+}
+
+.tournament-select-wrapper .tournament-select:hover {
+    cursor: pointer;
+}
+
+.tournament-select-wrapper .tournament-select:focus {
+    border-color: #ff5722;
+    outline: none;
+    box-shadow: 0 0 0 2px rgba(255, 87, 34, 0.2);
+}
+
+/**
+ 순위표 - 스테이지 버튼
+ */
+.stage-buttons {
+    margin-bottom: 1rem;
+    display: flex;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+}
+
+.stage-buttons button {
+    padding: 0.5rem 1rem;
+    border: 1px solid #ccc;
+    background: white;
+    cursor: pointer;
+    border-radius: 4px;
+    font-size: 12px;
+}
+
+.stage-buttons .active {
+    background: #333;
+    color: white;
+    border-color: #333;
+}
+
+/* 순위표 스타일 */
+.ranking-container {
+    padding: 15px;
+    background-color: #ffffff;
+    border-radius: 12px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
+    max-width: 1200px;
+    margin: 0 auto;
+}
+
+.ranking-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+    gap: 20px;
+    margin-top: 20px;
+}
+
+.team-card {
+    padding: 10px 15px;
+    background-color: #f9fafb;
+    border: 1px solid #e0e0e0;
+    border-radius: 10px;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.06);
+    text-align: center;
+    transition: transform 0.2s, box-shadow 0.2s;
+
+    display: inline-flex;
+    align-content: center;
+    justify-content: space-between;
+}
+
+.team-card:hover {
+    transform: translateY(-4px);
+    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.08);
+}
+
+.team-rank {
+    display: inline-flex;
+    align-items: center;
+    font-size: 18px;
+    font-weight: bold;
+    padding: 6px 12px;
+    background-color: #e0e7ff;
+    color: #1f2937;
+    border-radius: 20px;
+}
+
+.team-rank-badge {
+    width: 32px;
+    height: 32px;
+    line-height: 32px;
+    border-radius: 50%;
+    font-weight: bold;
+    display: flex;
+    flex-direction: column;
+    text-align: center;
+    font-size: 16px;
+    margin: auto 0;
+    background-color: white;
+    color: #333;
+    border-bottom: 2px solid #333;
+}
+
+.team-rank-badge span {
+    flex-direction: column;
+}
+
+.team-rank-badge span:not(:first-child) {
+    font-size: 11px;
+    color: #444;
+    margin-top: -5px;
+}
+
+.team-icon {
+    border: 1px solid gray;
+    border-radius: 20%;
+    width: 65px;
+    height: 65px;
+    margin: auto 0;
+    background-color: #333333;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.team-info {
+    width: 130px;
+    margin: 0;
+}
+
+.team-info .team-name {
+    font-size: 18px;
+    font-weight: 600;
+    color: #333;
+    margin: 8px 0;
+}
+
+.team-info .team-record {
+    font-size: 14px;
+    color: #444;
+}
+
+.team-info .team-record span {
+    font-size: 12px;
+}
+
+
+.team-info .team-record .win {
+    color: #2e8b57; /* 승리 - 녹색 */
+    font-weight: 500;
+}
+
+.team-info .team-record .loss {
+    color: #c0392b; /* 패배 - 빨간색 */
+    font-weight: 500;
+}
+
+.team-info .team-record span:not(:last-child)::after {
+    content: ' | ';
+    color: #333;
+}
+
+.no-ranking {
+    text-align: center;
+    font-size: 18px;
+    color: #b0b0b0;
+    margin-top: 40px;
+}
+

--- a/src/styles/css/style.css
+++ b/src/styles/css/style.css
@@ -20,20 +20,21 @@ body {
    헤더 스타일 (세련된 디자인)
 =============================== */
 header {
+    width: 100%;
+    position: fixed;
+    top: 0;
+    left: 0;
+    z-index: 1000;
+}
+
+.header-container {
     box-sizing: border-box;
     background-color: #333; /* 다크한 색상으로 고급스러운 느낌 */
     color: white;
     padding: 20px 30px;
-    position: sticky;
-    top: 0;
-    left: 0;
     width: 100%;
-    z-index: 1000;
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2); /* 더 부드러운 그림자 */
     border-bottom: 2px solid #444; /* 헤더 하단 경계선 */
-}
-
-.header-container {
     display: flex;
     justify-content: space-between;
     align-items: center;
@@ -614,4 +615,50 @@ header {
     #tokenExpirationTime::before {
         content: none;
     }
+}
+
+
+/**
+    nav, section
+ */
+.nav-container nav ul {
+    list-style-type: none;
+    display: flex;
+    background-color: #333;
+    padding: 0;
+    margin: 0;
+    flex-wrap: wrap;
+    justify-content: center;
+}
+
+.nav-container nav ul li {
+    padding: 10px;
+    margin-right: 10px;
+}
+
+.nav-container nav ul li a {
+    color: white;
+    text-decoration: none;
+}
+
+.nav-container nav ul li.active {
+    padding: 10px 15px 5px 15px;
+    border-bottom: 2px solid #ff5722;
+}
+
+
+.nav-container nav ul li.active a {
+    color: #ff5722;
+    font-weight: bold;
+}
+
+/* 각 섹션 스타일 */
+div.section {
+    /*background-color: lightgray;*/
+    /*border:1px solid gray;*/
+    display: flow-root;
+    scroll-margin-top: 170px; /* 헤더 크기만큼 스크롤 위치 아래로 */
+}
+div.section:not(:first-child) {
+    margin-top: 30px;
 }

--- a/src/utils/api-lol.js
+++ b/src/utils/api-lol.js
@@ -76,3 +76,27 @@ export async function getFavoritTeamSchedule(favoriteTeamCode) {
 
     return await response.json();
 }
+
+export async function apiFetchTournaments() {
+    const response = await fetch(`/api/lol/tournaments`, {
+        method: 'GET',
+    })
+
+    if (!response.ok) {
+        throw new Error('토너먼트 조회 실패');
+    }
+
+    return await response.json();
+}
+
+export async function apiFetchStandings(tournamentId) {
+    const response = await fetch(`/api/lol/standings/${tournamentId}`, {
+        method: 'GET',
+    })
+
+    if (!response.ok) {
+        throw new Error('순위 조회 실패');
+    }
+
+    return await response.json();
+}


### PR DESCRIPTION
- 토너먼트별 순위 조회 컴포넌트를 생성하고 화면에 표시되도록 구현
- 토너먼트 및 팀 순위 데이터를 가져오는 API 연동 완료
- 연도 및 월 선택이 가능한 셀렉트박스를 추가하여 유저가 원하는 시점을 편리하게 조회 가능하게 개선
- 네비게이션에 서브메뉴 기능 및 스타일 추가
- 메인 화면에서만 적용되는 nav-섹션 연동 스크롤 기능 구현 (섹션 구분 + nav 클릭 시 해당 영역으로 이동)
- API 요청 시 로딩 상태를 보여주는 로딩 컴포넌트 추가

2. [Refactor] 셀렉트박스 스타일 개선
- 기존 셀렉트박스의 레이아웃 및 UI 요소 개선
- 날짜 선택 시 사용자 경험 향상을 위한 스타일 조정

3. [Chore] 주별 경기일정 조회 기능 임시 비활성화
- 현재 사용되지 않는 주간 경기 일정 관련 기능을 주석 처리
- 추후 기능 활성화를 고려하여 코드 보존