### PR TITLE
[Feat] 리그 및 연도 선택에 따라 순위표 동적 갱신

### DIFF
--- a/src/components/home/HomePage.jsx
+++ b/src/components/home/HomePage.jsx
@@ -2,23 +2,26 @@ import "@/styles/css/chat.css";
 import "@/styles/css/standings.css";
 
 import { useAuth } from "@/context/AuthContext";
+import {CalandarProvider} from "@/context/CalendarContext.js";
 import SectionCalendar from "@/components/home/SectionCalendar";
 import SectionStandings from "@components/home/SectionStandings";
 import ChatButton from "@components/home/ChatButton";
-import Chat from "@components/home/Chat";
+import Chat from "@components/home/Chat.jsx";
 
 export default function HomePage() {
     const { userId } = useAuth();
 
     return (
         <main className="home-container">
-            <div className="section" id="section1">
-                <SectionCalendar />
-            </div>
+            <CalandarProvider>
+                <div className="section" id="section1">
+                    <SectionCalendar />
+                </div>
 
-            <div className="section" id="section2">
-                <SectionStandings />
-            </div>
+                <div className="section" id="section2">
+                    <SectionStandings />
+                </div>
+            </CalandarProvider>
 
             {userId ? <Chat /> : <ChatButton />}
         </main>

--- a/src/components/home/SectionCalendar.jsx
+++ b/src/components/home/SectionCalendar.jsx
@@ -1,10 +1,7 @@
-import { CalandarProvider } from "@/context/CalandarContext";
 import MyCalendar from "@components/lol/calendar/MyCalendar";
 
 export default function SectionCalendar() {
     return (
-        <CalandarProvider>
-            <MyCalendar />
-        </CalandarProvider>
+        <MyCalendar />
     );
 }

--- a/src/components/home/SectionStandings.jsx
+++ b/src/components/home/SectionStandings.jsx
@@ -2,8 +2,10 @@ import { useEffect, useState } from "react";
 import Standings from "@components/lol/standings/Standings";
 import Loading from "@components/common/Loading";
 import { apiFetchTournaments } from "@utils/api-lol";
+import {useCalendar} from "@/context/CalendarContext.js";
 
 export default function SectionStandings() {
+    const { selectedLeague, selectedDate } = useCalendar();
     const [tournaments, setTournaments] = useState([]);
     const [activeTournamentId, setActiveTournamentId] = useState('');
     const [isLoading, setIsLoading] = useState(true);
@@ -11,7 +13,7 @@ export default function SectionStandings() {
     useEffect(() => {
         const fetchTournaments = async () => {
             setIsLoading(true);
-            const response = await apiFetchTournaments();
+            const response = await apiFetchTournaments(selectedLeague.id, selectedDate.getFullYear());
             setTournaments(response);
             if (response.length > 0) {
                 const ongoing = response.find(t => t.active);
@@ -20,7 +22,8 @@ export default function SectionStandings() {
             setIsLoading(false);
         };
         fetchTournaments();
-    }, []);
+    }, [selectedLeague, selectedDate]);
+
 
     return isLoading ? (
         <Loading message="토너먼트 불러오는 중..." />

--- a/src/components/lol/calendar/FavoriteTeamButton.jsx
+++ b/src/components/lol/calendar/FavoriteTeamButton.jsx
@@ -1,12 +1,12 @@
 import { useEffect, useState } from 'react';
 import { FaStar, FaRegStar } from 'react-icons/fa';
-import { useCalandar } from "@/context/CalandarContext.js";
+import { useCalendar } from "@/context/CalendarContext.js";
 import { apiAddFavoriteTeam, apiRemoveFavoriteTeam } from "@utils/api-lol.js";
 import { useAuth } from "@/context/AuthContext.js";  // userId가 있는 곳
 
 const FavoriteTeamButton = ({ teamId, name, slug, image }) => {
     const { userId } = useAuth(); // userId 가져오기
-    const { selectedTeam, setSelectedTeam, favoriteTeamIds, setFavoriteTeamIds } = useCalandar(); // ⬅️ context에서 함수 가져오기
+    const { selectedTeam, setSelectedTeam, favoriteTeamIds, setFavoriteTeamIds } = useCalendar(); // ⬅️ context에서 함수 가져오기
     const [hovered, setHovered] = useState(false); // 버튼 개별 상태
     const [isFavorited, setIsFavorited] = useState(favoriteTeamIds.includes(teamId));
 

--- a/src/components/lol/calendar/LeagueAndTeamSelector.jsx
+++ b/src/components/lol/calendar/LeagueAndTeamSelector.jsx
@@ -1,5 +1,5 @@
 import {useEffect, useState} from "react";
-import {useCalandar} from "@/context/CalandarContext";
+import {useCalendar} from "@/context/CalendarContext.js";
 import {useAuth} from "@/context/AuthContext.js";
 import FavoriteTeamButton from "@components/lol/calendar/FavoriteTeamButton.jsx";
 import LeagueDropdown from "@components/lol/calendar/LeagueDropdown.jsx";
@@ -8,7 +8,7 @@ const LeagueAndTeamSelector = ({ leagues }) => {
     const [rawTeams, setRawTeams] = useState([]); // 👈 fetch 결과만 보관
     const [teams, setTeams] = useState([]);       // 👈 정렬된 최종 데이터
 
-    const {selectedLeague, setSelectedLeague, favoriteTeamIds} = useCalandar();
+    const {selectedLeague, setSelectedLeague, favoriteTeamIds} = useCalendar();
     const {userId} = useAuth();
 
 

--- a/src/components/lol/calendar/MyCalendar.jsx
+++ b/src/components/lol/calendar/MyCalendar.jsx
@@ -15,7 +15,7 @@ import {useCalendarLogic} from '@/components/lol/calendar/hooks/useCalendarLogic
 import {eventPropGetter} from '@/components/lol/calendar/utils/calendarEventStyles';
 import {formats} from '@/components/lol/calendar/config/formats';
 import LeagueAndTeamSelector from '@components/lol/calendar/LeagueAndTeamSelector';
-import {useCalandar} from "@/context/CalandarContext.js";
+import {useCalendar} from "@/context/CalendarContext.js";
 
 const localizer = dateFnsLocalizer({
     format, parse, startOfWeek: () => startOfWeek(new Date(), { weekStartsOn: 0 }), getDay,
@@ -28,11 +28,11 @@ const localizer = dateFnsLocalizer({
 const MyCalendar = ({ events }) => {
     const {
         leagues,
-        currentDate, setCurrentDate,
         currentView, setCurrentView,
         refinedSchedules
     } = useCalendarLogic();
-    const { selectedTeam, favoriteTeamIds } = useCalandar();
+    const { selectedTeam, favoriteTeamIds,
+       selectedDate, setSelectedDate} = useCalendar();
 
     return (
         <div className="calandar-container">
@@ -49,8 +49,8 @@ const MyCalendar = ({ events }) => {
                     day: true,          // 기본 일간 뷰
                     week: CustomVerticalWeekView, // 커스텀 주간 뷰 (요일 세로)
                 }}*/
-                date={currentDate}
-                onNavigate={setCurrentDate}
+                date={selectedDate}
+                onNavigate={setSelectedDate}
                 onView={setCurrentView}
                 eventPropGetter={(event) => eventPropGetter(event, selectedTeam, favoriteTeamIds)}
                 components={{

--- a/src/components/lol/calendar/hooks/useCalendarLogic.js
+++ b/src/components/lol/calendar/hooks/useCalendarLogic.js
@@ -1,7 +1,7 @@
 import { useEffect, useState, useCallback } from 'react';
 import { getMatchesByYearAndLeagueId, fetchFavoriteTeam } from '@utils/api-lol';
 import { useAuth } from '@/context/AuthContext';
-import { useCalandar } from '@/context/CalandarContext';
+import { useCalendar } from '@/context/CalendarContext.js';
 import { refineTeamSchedule } from '@/components/lol/calendar/utils/refineTeamSchedule';
 
 /**
@@ -10,14 +10,13 @@ import { refineTeamSchedule } from '@/components/lol/calendar/utils/refineTeamSc
 export const useCalendarLogic = () => {
     const { userId } = useAuth();
     const {
-        selectedLeague,
-        setSelectedLeague,
+        selectedLeague, setSelectedLeague,
         selectedTeam,
-        favoriteTeamIds,
-        setFavoriteTeamIds
-    } = useCalandar();
+        favoriteTeamIds, setFavoriteTeamIds,
+        selectedDate, setSelectedDate
+    } = useCalendar();
 
-    const [currentDate, setCurrentDate] = useState(new Date());
+    // const [currentDate, setCurrentDate] = useState(new Date());
     const [currentView, setCurrentView] = useState('month');
     const [rawSchedules, setRawSchedules] = useState([]);
     const [refinedSchedules, setRefinedSchedules] = useState([]);
@@ -48,11 +47,11 @@ export const useCalendarLogic = () => {
                 const data = await fetchFavoriteTeam();
                 setFavoriteTeamIds(data.map((team) => team.teamId));
             }
-            const matches = await getMatchesByYearAndLeagueId(currentDate.getFullYear(), selectedLeague?.id);
+            const matches = await getMatchesByYearAndLeagueId(selectedDate.getFullYear(), selectedLeague?.id);
             setRawSchedules(matches);
         };
         fetchSchedule();
-    }, [userId, selectedLeague, currentDate]);
+    }, [userId, selectedLeague, selectedDate]);
 
     useEffect(() => {
         setRefinedSchedules(refineTeamSchedule(rawSchedules, currentView));
@@ -60,8 +59,6 @@ export const useCalendarLogic = () => {
 
     return {
         leagues,
-        currentDate,
-        setCurrentDate,
         currentView,
         setCurrentView,
         refinedSchedules

--- a/src/context/CalendarContext.js
+++ b/src/context/CalendarContext.js
@@ -1,23 +1,26 @@
 "use client";
 
-// src/context/CalandarContext.js
+// src/context/CalendarContext.js
 import React, {createContext, useContext, useEffect, useState} from 'react';
 
-const CalandarContext = createContext({
+const CalendarContext = createContext({
     selectedLeague: null,   // 현재 선택된 리그
     selectedTeam: null,     // 현재 선택된 팀
     favoriteTeamIds: [],
+    selectedDate: [],
     setSelectedLeague: () => {},
     setSelectedTeam: () => {},
-    setFavoriteTeamIds: () => {}
+    setFavoriteTeamIds: () => {},
+    setSelectedDate: () => {}
 });
 
-export const useCalandar = () => useContext(CalandarContext);
+export const useCalendar = () => useContext(CalendarContext);
 
 export const CalandarProvider = ({ children }) => {
     const [selectedLeague, setSelectedLeague] = useState(null);
     const [selectedTeam, setSelectedTeam] = useState(null);
     const [favoriteTeamIds, setFavoriteTeamIds] = useState([]);
+    const [selectedDate, setSelectedDate] = useState(new Date());
 
     useEffect(() => {
         // console.log('selectedTeam 변경됨:', selectedTeam);
@@ -28,12 +31,13 @@ export const CalandarProvider = ({ children }) => {
     }, [favoriteTeamIds]);
 
     return (
-        <CalandarContext.Provider value={{
+        <CalendarContext.Provider value={{
             selectedLeague, setSelectedLeague,
             selectedTeam, setSelectedTeam,
-            favoriteTeamIds, setFavoriteTeamIds
+            favoriteTeamIds, setFavoriteTeamIds,
+            selectedDate, setSelectedDate
         }}>
             {children}
-        </CalandarContext.Provider>
+        </CalendarContext.Provider>
     );
 };

--- a/src/utils/api-lol.js
+++ b/src/utils/api-lol.js
@@ -93,8 +93,8 @@ export async function getFavoritTeamSchedule(favoriteTeamCode) {
     return await response.json();
 }
 
-export async function apiFetchTournaments() {
-    const response = await fetch(`/api/lol/tournaments`, {
+export async function apiFetchTournaments(leagueId, year) {
+    const response = await fetch(`/api/lol/tournaments?leagueId=${leagueId}&year=${year}`, {
         method: 'GET',
     })
 


### PR DESCRIPTION
- 선택된 리그 정보를 context로 관리하여 달력 및 순위표에서 공유
- 기존 LCK + 금년도 고정 조회 로직을 선택값 기반 동적 조회로 수정
- 리그 또는 연도 변경 시 해당 토너먼트별 순위표 조회