### PR TITLE
[Feat] 경기 일정 상세 팝업 정보 수정

### DIFF
--- a/src/components/home/SectionStandings.jsx
+++ b/src/components/home/SectionStandings.jsx
@@ -12,6 +12,8 @@ export default function SectionStandings() {
 
     useEffect(() => {
         const fetchTournaments = async () => {
+            if (!selectedLeague) return;
+
             setIsLoading(true);
             const response = await apiFetchTournaments(selectedLeague.id, selectedDate.getFullYear());
             setTournaments(response);

--- a/src/components/lol/calendar/CustomEventWrapper.jsx
+++ b/src/components/lol/calendar/CustomEventWrapper.jsx
@@ -42,7 +42,10 @@ const CustomEventWrapper = ({ event, children }) => {
                         .join(' vs ')}
                     </strong>
                 </div>
-                <div>{event.participants?.map(participant => participant.gameWins).join(" : ")}</div>
+                { event.state === 'unstarted'
+                    ? <div>{event.strategy}</div>
+                    : <div>{event.participants?.map(participant => participant.gameWins).join(" : ")}</div>
+                }
             </div>
         </Popup>
     );


### PR DESCRIPTION
- 경기 진행 중 및 종료 시 세트 스코어 표시
- 경기 시작 전일 경우 경기 진행 방식(strategy) 표시

[Fix] 리그 선택 전 토너먼트 fetch 방지
- 리그 선택이 완료되기 전에는 토너먼트 API 호출하지 않도록 조건 추가