### PR TITLE
[Feat] 경기 일정 조회 기능 개선 및 팝업 기능 추가

### DIFF
--- a/src/components/home/SectionStandings.jsx
+++ b/src/components/home/SectionStandings.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import {useEffect, useRef, useState} from "react";
 import Standings from "@components/lol/standings/Standings";
 import Loading from "@components/common/Loading";
 import { apiFetchTournaments } from "@utils/api-lol";
@@ -9,10 +9,16 @@ export default function SectionStandings() {
     const [tournaments, setTournaments] = useState([]);
     const [activeTournamentId, setActiveTournamentId] = useState('');
     const [isLoading, setIsLoading] = useState(true);
+    const prevLeagueRef = useRef(null);
 
     useEffect(() => {
         const fetchTournaments = async () => {
             if (!selectedLeague) return;
+
+            // 리그 선택값에 변경사항이 없으면 패스
+            if (prevLeagueRef.current === selectedLeague) return;
+
+            prevLeagueRef.current = selectedLeague;
 
             setIsLoading(true);
             const response = await apiFetchTournaments(selectedLeague.id, selectedDate.getFullYear());

--- a/src/components/lol/calendar/CustomEventWrapper.jsx
+++ b/src/components/lol/calendar/CustomEventWrapper.jsx
@@ -14,7 +14,7 @@ const CustomEventWrapper = ({ event, children }) => {
     return (
         <Popup
             trigger={
-                <div>
+                <div onClick={(e) => e.stopPropagation()}>
                     {children}  {/*refineTeamSchedule > title*/}
                 </div>
             }

--- a/src/components/lol/calendar/MatchListPopup.jsx
+++ b/src/components/lol/calendar/MatchListPopup.jsx
@@ -1,0 +1,55 @@
+import Popup from 'reactjs-popup';
+import 'reactjs-popup/dist/index.css';
+import { format } from 'date-fns';
+import ko from "date-fns/locale/ko";
+
+const MatchListPopup = ({ open, onClose, matches, date }) => {
+    return (
+        <Popup open={open} onClose={onClose} modal closeOnDocumentClick
+               contentStyle={{
+                   width: '90vw',
+                   maxWidth: '500px',
+                   maxHeight: '90vh',
+                   overflowY: 'auto',
+                   position: 'fixed',
+                   top: '50%',
+                   left: '50%',
+                   transform: 'translate(-50%, -50%)'
+               }}
+        >
+            <div className="custom-event-popup text-sm p-4">
+                {/*<h2 className="text-lg font-bold mb-2">경기 일정</h2>*/}
+                <div className="text-lg font-bold mb-2 border-b py-2">
+                    {format(new Date(date), 'yyyy년 M월 d일 (EEE)', { locale: ko })}
+                </div>
+                {matches.length === 0 ? (
+                    <p>해당 날짜에 경기가 없습니다.</p>
+                ) : (
+                    matches.map((match, idx) => {
+                        const codes = match.participants?.map(p => p.team.code);
+                        return (
+                            <div key={match.id || idx} className="border-b py-2">
+                                { match.state === 'inProgress' &&
+                                    <div className="live-badge inline-flex"></div>
+                                }
+                                <span>{format(new Date(match.startTime), 'HH:mm')}</span>
+                                <div className="font-semibold">
+                                    {codes?.map(code =>
+                                        code === match.winningTeamCode ? `${code}(승)` : code
+                                    ).join(' vs ')}
+                                </div>
+                                <div>
+                                    {new Date(match.startTime) > new Date()
+                                        ? match.strategy
+                                        : match.participants?.map(p => p.gameWins).join(' : ')}
+                                </div>
+                            </div>
+                        );
+                    })
+                )}
+            </div>
+        </Popup>
+    );
+};
+
+export default MatchListPopup;

--- a/src/components/lol/calendar/MyCalendar.jsx
+++ b/src/components/lol/calendar/MyCalendar.jsx
@@ -16,11 +16,15 @@ import {eventPropGetter} from '@/components/lol/calendar/utils/calendarEventStyl
 import {formats} from '@/components/lol/calendar/config/formats';
 import LeagueAndTeamSelector from '@components/lol/calendar/LeagueAndTeamSelector';
 import {useCalendar} from "@/context/CalendarContext.js";
+import {getMatchesByLeagueIdAndDate} from "@utils/api-lol.js";
+import {getDateRange} from "@utils/date-util.js";
+import MatchListPopup from "@components/lol/calendar/MatchListPopup.jsx";
 
 const localizer = dateFnsLocalizer({
     format, parse, startOfWeek: () => startOfWeek(new Date(), { weekStartsOn: 0 }), getDay,
     locales: { ko }
 });
+
 
 /**
  * [React 컴포넌트 파일] 대문자 시작
@@ -29,10 +33,13 @@ const MyCalendar = ({ events }) => {
     const {
         leagues,
         currentView, setCurrentView,
-        refinedSchedules
+        refinedSchedules,
+        popupMatches, setPopupMatches, popupOpen, setPopupOpen,
     } = useCalendarLogic();
-    const { selectedTeam, favoriteTeamIds,
-       selectedDate, setSelectedDate} = useCalendar();
+    const { selectedLeague,
+        selectedTeam, favoriteTeamIds,
+        selectedDate, setSelectedDate
+    } = useCalendar();
 
     return (
         <div className="calandar-container">
@@ -81,7 +88,24 @@ const MyCalendar = ({ events }) => {
                     ),
                 }}
                 selectable
+                onSelectSlot={async (slotInfo) => {
+                    const { startDate, endDate } = getDateRange('day', slotInfo.start);
+                    const response = await getMatchesByLeagueIdAndDate(selectedLeague.id, startDate, endDate);
+
+                    setPopupMatches(response);
+                    setPopupOpen(true);
+                }}
             />
+            {popupOpen && (
+                    <MatchListPopup
+                        open={popupOpen}
+                        onClose={() => setPopupOpen(false)}
+                        matches={popupMatches}
+                        date={selectedDate}
+                    />
+                )
+            }
+
             <LeagueAndTeamSelector leagues={leagues} />
         </div>
     );

--- a/src/components/lol/calendar/hooks/useCalendarLogic.js
+++ b/src/components/lol/calendar/hooks/useCalendarLogic.js
@@ -1,8 +1,9 @@
-import { useEffect, useState, useCallback } from 'react';
-import { getMatchesByYearAndLeagueId, fetchFavoriteTeam } from '@utils/api-lol';
-import { useAuth } from '@/context/AuthContext';
-import { useCalendar } from '@/context/CalendarContext.js';
-import { refineTeamSchedule } from '@/components/lol/calendar/utils/refineTeamSchedule';
+import {useEffect, useRef, useState} from 'react';
+import {fetchFavoriteTeam, getMatchesByLeagueIdAndDate} from '@utils/api-lol';
+import {useAuth} from '@/context/AuthContext';
+import {useCalendar} from '@/context/CalendarContext.js';
+import {refineTeamSchedule} from '@/components/lol/calendar/utils/refineTeamSchedule';
+import {getDateRange} from "@utils/date-util.js";
 
 /**
  * [훅(Hook)] 소문자 시작 (use prefix)
@@ -16,11 +17,14 @@ export const useCalendarLogic = () => {
         selectedDate, setSelectedDate
     } = useCalendar();
 
-    // const [currentDate, setCurrentDate] = useState(new Date());
     const [currentView, setCurrentView] = useState('month');
     const [rawSchedules, setRawSchedules] = useState([]);
     const [refinedSchedules, setRefinedSchedules] = useState([]);
     const [leagues, setLeagues] = useState([]);
+    const [popupOpen, setPopupOpen] = useState(false);
+    const [popupMatches, setPopupMatches] = useState([]);
+    const prevYearRef = useRef(null);
+    const prevLeagueRef = useRef(null);
 
     // 리그 불러오기
     useEffect(() => {
@@ -42,16 +46,32 @@ export const useCalendarLogic = () => {
     // 일정 불러오기
     useEffect(() => {
         const fetchSchedule = async () => {
-            if (!selectedLeague) return;
+            if (!selectedLeague || !selectedDate) return;
+
+            const year = selectedDate.getFullYear();
+
+            // 연도 또는 리그 선택값에 변경사항이 없는 경우 패스
+            if (prevYearRef.current === year && prevLeagueRef.current === selectedLeague) return;
+
+            // 연도 변경 → 새로 불러오기
+            prevYearRef.current = year;
+            prevLeagueRef.current = selectedLeague;
+
             if (userId) {
                 const data = await fetchFavoriteTeam();
                 setFavoriteTeamIds(data.map((team) => team.teamId));
             }
-            const matches = await getMatchesByYearAndLeagueId(selectedDate.getFullYear(), selectedLeague?.id);
-            setRawSchedules(matches);
+
+            const { startDate, endDate } = getDateRange(currentView, selectedDate);
+            if (startDate && endDate) {
+                const matches = await getMatchesByLeagueIdAndDate(selectedLeague?.id, startDate, endDate);
+                setRawSchedules(matches);
+            } else {
+                // 검색 조건 불충분 처리
+            }
         };
         fetchSchedule();
-    }, [userId, selectedLeague, selectedDate]);
+    }, [userId, selectedLeague, selectedDate, currentView]);
 
     useEffect(() => {
         setRefinedSchedules(refineTeamSchedule(rawSchedules, currentView));
@@ -61,6 +81,10 @@ export const useCalendarLogic = () => {
         leagues,
         currentView,
         setCurrentView,
-        refinedSchedules
+        refinedSchedules,
+        popupMatches,
+        setPopupMatches,
+        popupOpen,
+        setPopupOpen
     };
 };

--- a/src/utils/api-lol.js
+++ b/src/utils/api-lol.js
@@ -65,11 +65,25 @@ export async function getAllSchedules() {
     return await response.json();
 }
 
-// TODO 달력에서 조회중인 날짜 기준으로 데이터 조회하도록 수정
-export async function getMatchesByYearAndLeagueId(year, leagueId) {
-    const currentYear = year || new Date().getFullYear();
+// 첫 진입 시 해당년도 전체 경기일정 조회
+/*
+export async function getMatchesByLeagueIdAndYear(leagueId, year) {
+    const response = await fetch(`/api/lol/matches?leagueId=${leagueId}&year=${year}`, {
+        method: 'GET',
+        credentials: 'include'
+    });
 
-    const response = await fetch(`/api/lol/matches?year=${currentYear}&leagueId=${leagueId}`, {
+    if (!response.ok) {
+        throw new Error('경기 일정 조회 실패');
+    }
+
+    return await response.json();
+}
+*/
+
+// 달력에서 선택한 날짜 기준으로 데이터 조회
+export async function getMatchesByLeagueIdAndDate(leagueId, startDate, endDate) {
+    const response = await fetch(`/api/lol/matches?leagueId=${leagueId}&startDate=${startDate}&endDate=${endDate}`, {
         method: 'GET',
         credentials: 'include'
     });

--- a/src/utils/date-util.js
+++ b/src/utils/date-util.js
@@ -1,0 +1,39 @@
+export function getDateRange(view, date) {
+    let year, month, day;
+    if (view === 'month') {
+        year = date.getFullYear();
+        // month = date.getMonth() + 1;
+    } else if (view === 'week') {
+        // TODO
+    } else {
+        year = date.getFullYear();
+        month = date.getMonth() + 1;
+        day = date.getDate();
+    }
+
+    if (!year) return null; // 연도 없으면 검색 안 함 or 기본값 처리
+
+    let startDate, endDate;
+
+    if (year && !month) {
+        // 연도만
+        startDate = `${year}-01-01`;
+        endDate = `${year}-12-31`;
+    } else if (year && month && !day) {
+        // 연도 + 월
+        const paddedMonth = String(month).padStart(2, '0');
+        const lastDay = new Date(year, month, 0).getDate();
+        startDate = `${year}-${paddedMonth}-01`;
+        endDate = `${year}-${paddedMonth}-${String(lastDay).padStart(2, '0')}`;
+    } else if (year && month && day) {
+        // 연도 + 월 + 일
+        const paddedMonth = String(month).padStart(2, '0');
+        const paddedDay = String(day).padStart(2, '0');
+        startDate = `${year}-${paddedMonth}-${paddedDay}`;
+        endDate = startDate;
+    } else {
+        return null; // 조건이 불완전하면 null 리턴
+    }
+
+    return { startDate, endDate };
+}


### PR DESCRIPTION
- 연도별 조회 → 연/월/일 기준 조회로 변경
- 일별 경기 일정 팝업 표시 기능 추가
- 리그 선택값 변경 시에만 토너먼트 데이터 fetch
- 연도 또는 리그 변경 시에만 즐겨찾기 팀 및 경기 일정 fetch