### PR TITLE
[feat] 달력 좌우 스와이프 기능 구현

### DIFF
--- a/src/components/lol/calendar/CustomEventWrapper.jsx
+++ b/src/components/lol/calendar/CustomEventWrapper.jsx
@@ -62,6 +62,14 @@ const CustomEventWrapper = ({ open, event, children }) => {
                                             </div>
                                         </div>
 
+                                        {isLive && (
+                                            <div className="flex justify-center">
+                                                <div className="label strategy">
+                                                    {event.strategy}
+                                                </div>
+                                            </div>
+                                        )}
+
                                         {isUnstarted ? (
                                             <div className="teams-row">
                                                 <div className="team team-left">

--- a/src/components/lol/calendar/MatchListPopup.jsx
+++ b/src/components/lol/calendar/MatchListPopup.jsx
@@ -12,7 +12,7 @@ function MatchListPopup ({ open, onClose, matches, date, isLoading, onPrevDate, 
     const handlers = useSwipeable({
         onSwipedLeft: () => onNextDate(),  // 오른쪽에서 왼쪽으로 스와이프 → 다음 날짜
         onSwipedRight: () => onPrevDate(), // 왼쪽에서 오른쪽으로 스와이프 → 이전 날짜
-        preventScrollOnSwipe: true,
+        preventScrollOnSwipe: true, // 스와이프가 인식되었을 때만 preventDefault()를 호출해서 브라우저 스크롤을 막음
         trackMouse: true, // 데스크탑에서도 마우스로 테스트 가능
     });
 
@@ -71,6 +71,14 @@ function MatchListPopup ({ open, onClose, matches, date, isLoading, onPrevDate, 
                                                     <span>{format(new Date(match.startTime), 'HH:mm')}</span>
                                                 </div>
                                             </div>
+
+                                            {isLive && (
+                                                <div className="flex justify-center">
+                                                    <div className="label strategy">
+                                                        {match.strategy}
+                                                    </div>
+                                                </div>
+                                            )}
 
                                             {isUnstarted ? (
                                                 <div className="teams-row">

--- a/src/components/lol/calendar/MyCalendar.jsx
+++ b/src/components/lol/calendar/MyCalendar.jsx
@@ -6,8 +6,9 @@ import 'react-big-calendar/lib/css/react-big-calendar.css';
 import '@/styles/tailwind/lol/calendar.css';
 import '@/styles/css/lol-calendar.css';
 
-import {format, getDay, parse, startOfWeek} from 'date-fns';
+import {addDays, addMonths, format, getDay, parse, startOfWeek, subDays, subMonths} from 'date-fns';
 import ko from 'date-fns/locale/ko';
+import {useSwipeable} from 'react-swipeable'
 
 import CustomToolbar from '@components/lol/calendar/CustomToolbar';
 import CustomEventWrapper from '@components/lol/calendar/CustomEventWrapper';
@@ -44,6 +45,7 @@ function MyCalendar ({ events }) {
     } = useCalendar();
 
 
+    // 경기 일정 타이틀 (ex. T1 vs GEN)
     function CalendarEvent({ event }) {
         const isInProgress = event.state === 'inProgress';
         return (
@@ -54,7 +56,30 @@ function MyCalendar ({ events }) {
         );
     }
 
-    // 경기 일정 팝업 핸들러
+    // 월간/일간 달력 스와이프 핸들러
+    const handlers = useSwipeable({
+        onSwipedLeft: () => {
+            if (currentView === 'month') {
+                setSelectedDate(prev => addMonths(prev, 1));
+            } else if (currentView === 'day') {
+                setSelectedDate(prev => addDays(prev, 1));
+            }
+        },
+        onSwipedRight: () => {
+            if (currentView === 'month') {
+                setSelectedDate(prev => subMonths(prev, 1));
+            } else if (currentView === 'day') {
+                setSelectedDate(prev => subDays(prev, 1));
+            }
+        },
+        // preventDefaultTouchmoveEvent: true, // 모든 터치 이동(좌우든 상하든)에 대해 기본 스크롤이 무조건 방지
+        preventScrollOnSwipe: true, // 스와이프가 인식되었을 때만 preventDefault()를 호출해서 브라우저 스크롤을 막음
+        trackMouse: true,
+    });
+
+
+
+    // 일간 경기 일정 목록  팝업 핸들러
     const handlePrevDate = async () => {
         const newDate = new Date(popupDate);
         newDate.setDate(newDate.getDate() - 1);
@@ -89,47 +114,51 @@ function MyCalendar ({ events }) {
 
     return (
         <div className="calendar-container">
-            <Calendar
-                localizer={localizer}
-                formats={formats}
-                events={events || refinedSchedules}
-                startAccessor="start"
-                endAccessor="end"
-                defaultView="month"
-                views={['month', 'week', 'day']}
-                /*views={{
-                    month: true,        // 기본 월간 뷰
-                    day: true,          // 기본 일간 뷰
-                    week: CustomVerticalWeekView, // 커스텀 주간 뷰 (요일 세로)
-                }}*/
-                date={selectedDate}
-                onNavigate={setSelectedDate}
-                onView={setCurrentView}
-                eventPropGetter={(event) => eventPropGetter(event, selectedTeam, favoriteTeamIds)}
-                components={{
-                    toolbar: CustomToolbar,
-                    event: CalendarEvent,
-                    eventWrapper: CustomEventWrapper,
-                    month: {
-                        dateHeader: ({ date, label }) => (
-                            <div style={{ color: date.getDay() === 0 ? 'red' : undefined }}>
+            <div className="calendar-wrapper" {...handlers}>
+                <Calendar
+                    localizer={localizer}
+                    formats={formats}
+                    events={events || refinedSchedules}
+                    startAccessor="start"
+                    endAccessor="end"
+                    defaultView="month"
+                    views={['month', 'week', 'day']}
+                    /*views={{
+                        month: true,            // 기본 월간 뷰
+                        day: CustomDayView,     // TODO 커스텀 일간 뷰
+                        week: true,             // 기본 주간 뷰
+                    }}*/
+                    date={selectedDate}
+                    onNavigate={setSelectedDate}
+                    onView={setCurrentView}
+                    eventPropGetter={(event) => eventPropGetter(event, selectedTeam, favoriteTeamIds)}
+                    components={{
+                        toolbar: CustomToolbar,
+                        event: CalendarEvent,
+                        eventWrapper: CustomEventWrapper,
+                        month: {
+                            dateHeader: ({ date, label }) => (
+                                <div style={{ color: date.getDay() === 0 ? 'red' : undefined }}>
+                                    {label}
+                                </div>
+                            ),
+                        },
+                        header: ({ date, label }) => (
+                            <div style={{ color: date.getDay() === 0 ? 'red' : 'inherit' }}>
                                 {label}
                             </div>
                         ),
-                    },
-                    header: ({ date, label }) => (
-                        <div style={{ color: date.getDay() === 0 ? 'red' : 'inherit' }}>
-                            {label}
-                        </div>
-                    ),
-                }}
-                selectable
-                longPressThreshold={100} // 터치로 인정할 시간. 기본 250
-                onSelectSlot={async (slotInfo) => {
-                    if (!slotInfo?.start) return;
-                    fetchMatchesForDate(slotInfo.start);
-                }}
-            />
+                    }}
+                    selectable
+                    longPressThreshold={100} // 터치로 인정할 시간. 기본 250
+                    onSelectSlot={async (slotInfo) => {
+                        if (!slotInfo?.start) return;
+                        fetchMatchesForDate(slotInfo.start);
+                    }}
+                />
+            </div>
+
+            {/* 일간 경기 일정 목록 팝업 */}
             {popupOpen && (
                     <MatchListPopup
                         open={popupOpen}
@@ -143,6 +172,7 @@ function MyCalendar ({ events }) {
                 )
             }
 
+            {/* 리그&팀 필터 버튼 */}
             <LeagueAndTeamSelector leagues={leagues} />
         </div>
     );

--- a/src/styles/css/lol-calendar.css
+++ b/src/styles/css/lol-calendar.css
@@ -72,8 +72,12 @@
 }
 
 @media (max-width: 500px) {
-    .rbc-calendar {
+    .calendar-wrapper {
         height: calc(100% - 60px) !important;
+    }
+
+    .rbc-calendar {
+        height: 100% !important;
     }
 
     .custom-toolbar {
@@ -101,8 +105,12 @@
     color: #007bff;
 }
 
-.rbc-calendar {
+.calendar-wrapper {
     height: calc(100% - 70px);
+}
+
+.rbc-calendar {
+    height: 100%;
 }
 
 .rbc-calendar .custom-toolbar .label-area {


### PR DESCRIPTION
- 달력 영역을 별도 swipe target div로 분리
- 월간 뷰: 이전/다음 달 조회
- 일간 뷰: 이전/다음 날 조회

[fix] 일정 상세 및 일간 경기 팝업에서 진행 중 경기 strategy 표시
- 진행 중인 경기일 경우, 스코어 위에 strategy 배지 노출