### PR TITLE
[fix] 클라이언트 전용 로직으로 hydration mismatch 에러 방지

### DIFF
--- a/src/components/lol/standings/Standings.jsx
+++ b/src/components/lol/standings/Standings.jsx
@@ -10,6 +10,7 @@ const Standings = ({ tournamentId }) => {
     const [activeStageId, setActiveStageId] = useState('');
     const [activeSectionIndex, setActiveSectionIndex] = useState(0);
     const gridContainerRef = useRef(null);
+    const [hasMounted, setHasMounted] = useState(false);
     const [rankings, setRankings] = useState([]);
     const [rowCount, setRowCount] = useState(0);
 
@@ -27,6 +28,7 @@ const Standings = ({ tournamentId }) => {
     const activeStage = stages.find(stage => stage.id === activeStageId);
     const sections = activeStage?.sections || [];
     const activeSection = sections[activeSectionIndex] || null;
+
 
     useEffect(() => {
         const fetchData = async () => {
@@ -60,6 +62,8 @@ const Standings = ({ tournamentId }) => {
     }, [standings, activeStageId, activeSectionIndex]);
 
     useEffect(() => {
+        setHasMounted(true);
+
         const updateRowCount = () => {
             const containerWidth = gridContainerRef.current ? gridContainerRef.current.offsetWidth : window.innerWidth; // container의 너비를 확인
             const isMobile = containerWidth <= 450;
@@ -116,6 +120,9 @@ const Standings = ({ tournamentId }) => {
         return <Loading message="순위 데이터를 불러오는 중입니다..." />;
     }
 
+    // hydration mismatch 에러(서버가 만든 초안 HTML != 브라우저 렌더링 결과 HTML) 방지
+    // 아직 브라우저에서 안 열렸으면 아무것도 안 보여줌
+    if (!hasMounted) return null;
 
     return (
         <div className="ranking-container">


### PR DESCRIPTION
- 서버 사이드 렌더링(SSR) 시 window 객체가 없어 화면 너비 계산(window.innerWidth)이 불가능
- 이로 인해 서버와 클라이언트의 렌더 결과가 달라져 hydration mismatch 발생
- useEffect 내에서 클라이언트 전용 로직 실행되도록 수정
- 최초 렌더 시에는 조건부 렌더링(hasMounted)로 SSR과 CSR 결과 일치 보장