### PR TITLE
feat: 리그 순서 사용자 설정 기능 및 CSRF 토큰 발급 로직 추가

### DIFF
--- a/src/context/AuthContext.js
+++ b/src/context/AuthContext.js
@@ -2,7 +2,7 @@
 
 // src/context/AuthContext.js
 import React, { createContext, useContext, useState, useEffect } from 'react';
-import { refreshToken as refreshTokenApi, login as apiLogin } from "@/utils/api";
+import { refreshToken as refreshTokenApi, login as apiLogin, fetchCsrfToken } from "@/utils/api";
 import {useRouter} from "next/navigation.js"; // API 로직 분리된 곳에서 import
 
 // TODO userid, username 객체로 합치기
@@ -65,6 +65,9 @@ export const AuthProvider = ({ children }) => {
 
     // 로그인 상태 초기화
     useEffect(() => {
+        // CSRF 토큰 발급
+        fetchCsrfToken();
+
         const storedUserId = localStorage.getItem('userId');
         const storedUsername = localStorage.getItem('username');
         const storedExpirationTime = localStorage.getItem('expirationTime');

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -83,3 +83,15 @@ export async function refreshToken() {
 
     return await response.json();
 }
+
+export async function fetchCsrfToken() {
+    try {
+        // 백엔드 CsrfTokenController가 /csrf 경로에 매핑되어 있음
+        await fetch("/api/csrf", {
+            method: "GET",
+            credentials: "include"
+        });
+    } catch (e) {
+        console.error("CSRF 토큰 발급 실패", e);
+    }
+}


### PR DESCRIPTION
[Backend]
- LeagueService: 로그인하지 않은 경우(userId=null) 기본 사용자(0)의 정렬 순서 적용
- data.sql: 기본 리그 정렬 순서(LCK, 국제대회 등) 초기 데이터 추가
- SecurityConfig: /csrf 경로 permitAll 허용 (CSRF 토큰 발급용)

[Frontend]
- AuthContext: 앱 초기화 시 CSRF 토큰 발급 API(/api/csrf) 호출 추가
- api.js: fetchCsrfToken 함수 구현